### PR TITLE
Add new timestamping flag to wget

### DIFF
--- a/systemfixtures/processes/tests/test_wget.py
+++ b/systemfixtures/processes/tests/test_wget.py
@@ -14,11 +14,11 @@ class WgetTest(TestCase):
         self.wget = Wget(locations=self.locations)
 
     def test_to_stdout(self):
-        result = self.wget({"args": ["wget", "-O", "-", "http://x"]})
+        result = self.wget({"args": ["wget","-N", "-O", "-", "http://x"]})
         self.assertEqual(b"data", result["stdout"].getvalue())
 
     def test_to_file(self):
         temp_dir = self.useFixture(TempDir())
         path = temp_dir.join("output")
-        self.wget({"args": ["wget", "-O", path, "http://x"]})
+        self.wget({"args": ["wget", "-N", "-O", path, "http://x"]})
         self.assertThat(path, FileContains("data"))

--- a/systemfixtures/processes/wget.py
+++ b/systemfixtures/processes/wget.py
@@ -14,6 +14,7 @@ class Wget(object):
         parser.add_argument("url")
         parser.add_argument("-O", dest="output")
         parser.add_argument("-q", dest="quiet", action="store_true")
+        parser.add_argument("-N", dest="timestamping", action="store_true")
         parser.add_argument("--no-check-certificate", action="store_true")
         args = parser.parse_args(proc_args["args"][1:])
         content = self.locations[args.url]


### PR DESCRIPTION
This is related to changes to jenkins-charm where we're using `wget -N`:
https://github.com/jenkinsci/jenkins-charm/pull/63